### PR TITLE
force return of 400 when non nullable fields are passed

### DIFF
--- a/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/model/MockData.kt
+++ b/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/model/MockData.kt
@@ -3,11 +3,14 @@ package co.tala.api.fakedependency.model
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.util.CollectionUtils
+import javax.validation.constraints.NotNull
 
 
 class MockData(
     val responseBody: Any? = null,
+    @field: NotNull
     val responseSetUpMetadata: ResponseSetUpMetadata = ResponseSetUpMetadata(),
+    @field: NotNull
     val responseHeaders: Map<String, List<String>> = emptyMap()
 ) {
     fun toResponseEntity(): ResponseEntity<Any> = ResponseEntity(


### PR DESCRIPTION
With this change, if `responseSetUpMetadata` or `responseHeaders` have a `null` value, then the service will return a 400. If the property is missing from the request payload, it will successfully initialize with its default value.

https://stackoverflow.com/questions/52444699/kotlin-spring-bean-validation-nullability

Co-authored-by: Elliot Masor <44781950+elliot-masor@users.noreply.github.com>
Co-authored-by: Autumn Kennedy <autumn.kennedy@tala.co>

### Example 400

```
HTTP/1.1 400 
Content-Type: application/json
Transfer-Encoding: chunked
Date: Wed, 09 Mar 2022 22:21:13 GMT
Proxy-Connection: close

{
  "timestamp": "2022-03-09T22:21:13.683+0000",
  "status": 400,
  "error": "Bad Request",
  "errors": [
    {
      "codes": [
        "NotNull.mockData.responseSetUpMetadata",
        "NotNull.responseSetUpMetadata",
        "NotNull.co.tala.api.fakedependency.model.ResponseSetUpMetadata",
        "NotNull"
      ],
      "arguments": [
        {
          "codes": [
            "mockData.responseSetUpMetadata",
            "responseSetUpMetadata"
          ],
          "arguments": null,
          "defaultMessage": "responseSetUpMetadata",
          "code": "responseSetUpMetadata"
        }
      ],
      "defaultMessage": "must not be null",
      "objectName": "mockData",
      "field": "responseSetUpMetadata",
      "rejectedValue": null,
      "bindingFailure": false,
      "code": "NotNull"
    }
  ],
  "message": "Validation failed for object='mockData'. Error count: 1",
  "path": "/mock-service/amazon/mock-resources/cart"
}

Response code: 400; Time: 52ms; Content length: 693 bytes
```