### PR TITLE
update license for Inventure Capital Corporation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Tala (formerly Inventure)
+Copyright (c) 2022 Inventure Capital Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Update legal entity name from `Tala (formerly Inventure)` to `Inventure Capital Corporation`