### PR TITLE
update example client library with latest features

### DIFF
--- a/example-service-under-test/src/main/kotlin/co/tala/example/http/client/core/ContentType.kt
+++ b/example-service-under-test/src/main/kotlin/co/tala/example/http/client/core/ContentType.kt
@@ -1,0 +1,10 @@
+package co.tala.example.http.client.core
+
+enum class ContentType(val value: String) {
+    APPLICATION_JSON("application/json"),
+    TEXT_PLAIN("text/plain"),
+    APPLICATION_X_WWW_FORM_URLENCODED("application/x-www-form-urlencoded"),
+    APPLICATION_OFFSET_OCTET_STREAM("application/offset+octet-stream"),
+    APPLICATION_OCTET_STREAM("application/octet-stream"),
+    MULTIPART_FORM_DATA("multipart/form-data")
+}

--- a/example-service-under-test/src/main/kotlin/co/tala/example/http/client/core/request/BinaryBodyRequest.kt
+++ b/example-service-under-test/src/main/kotlin/co/tala/example/http/client/core/request/BinaryBodyRequest.kt
@@ -1,0 +1,24 @@
+package co.tala.example.http.client.core.request
+
+import co.tala.example.http.client.core.ContentType
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+
+interface BinaryBodyRequest {
+    fun toRequestBody(): RequestBody = binary().toRequestBody(contentType().value.toMediaType())
+    fun BinaryBodyRequest.contentType(): ContentType
+    fun BinaryBodyRequest.binary(): ByteArray
+}
+
+@Suppress("ArrayInDataClass")
+data class OffsetOctetStreamBodyRequest(private val binary: ByteArray) : BinaryBodyRequest {
+    override fun BinaryBodyRequest.contentType(): ContentType = ContentType.APPLICATION_OFFSET_OCTET_STREAM
+    override fun BinaryBodyRequest.binary(): ByteArray = binary
+}
+
+@Suppress("ArrayInDataClass")
+data class OctetStreamBodyRequest(private val binary: ByteArray) : BinaryBodyRequest {
+    override fun BinaryBodyRequest.contentType(): ContentType = ContentType.APPLICATION_OCTET_STREAM
+    override fun BinaryBodyRequest.binary(): ByteArray = binary
+}

--- a/example-service-under-test/src/main/kotlin/co/tala/example/http/client/core/request/FormBodyRequest.kt
+++ b/example-service-under-test/src/main/kotlin/co/tala/example/http/client/core/request/FormBodyRequest.kt
@@ -1,0 +1,14 @@
+package co.tala.example.http.client.core.request
+
+import okhttp3.FormBody
+import okhttp3.MediaType
+
+interface FormBodyRequest {
+    fun toRequestBody(): FormBody
+    fun FormBodyRequest.build(block: FormBody.Builder.() -> FormBody.Builder) =
+        FormBody.Builder().let { block(it).build() }
+}
+
+fun FormBody.Builder.tryAddFormData(name: String, value: String?) = apply {
+    if (value != null) add(name, value)
+}

--- a/example-service-under-test/src/main/kotlin/co/tala/example/http/client/core/request/MultipartBodyRequest.kt
+++ b/example-service-under-test/src/main/kotlin/co/tala/example/http/client/core/request/MultipartBodyRequest.kt
@@ -1,0 +1,26 @@
+package co.tala.example.http.client.core.request
+
+import co.tala.example.http.client.core.ContentType
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+
+interface MultipartBodyRequest {
+    fun toRequestBody(): MultipartBody
+    fun MultipartBodyRequest.contentType(): ContentType
+    fun MultipartBodyRequest.build(block: MultipartBody.Builder.() -> MultipartBody.Builder) =
+        MultipartBody.Builder().setType(contentType().value.toMediaType()).let { block(it).build() }
+}
+
+interface MultipartFormDataBodyRequest : MultipartBodyRequest {
+    override fun MultipartBodyRequest.contentType(): ContentType = ContentType.MULTIPART_FORM_DATA
+}
+
+fun MultipartBody.Builder.tryAddFormData(name: String, value: String?) = apply {
+    if (value != null) addFormDataPart(name, value)
+}
+
+fun MultipartBody.Builder.tryAddFormData(name: String, fileName: String?, body: RequestBody?) = apply {
+    if (body != null) addFormDataPart(name, fileName, body)
+}
+

--- a/example-service-under-test/src/main/kotlin/co/tala/example/http/client/lib/factory/ClientFactory.kt
+++ b/example-service-under-test/src/main/kotlin/co/tala/example/http/client/lib/factory/ClientFactory.kt
@@ -51,23 +51,23 @@ class ClientFactory<T>(
         val okHttpClient = OkHttpClient()
         val client = ExampleHttpClient(
             okHttpClient = okHttpClient,
+            requestHeaderBuilder = requestBuilder,
             baseUrl = baseUrl ?: this.baseUrl,
             gson = gson
         )
 
         @Suppress("IMPLICIT_CAST_TO_ANY", "UNCHECKED_CAST")
         return when (clazz) {
-            IMockUserClient::class.java -> MockUserClient(client, requestBuilder)
+            IMockUserClient::class.java -> MockUserClient(client)
             IMockImmunizationHistoryClient::class.java -> MockImmunizationHistoryClient(
                 client,
-                requestBuilder,
                 queryBuilder
             )
-            IMockPharmacyClient::class.java -> MockPharmacyClient(client, requestBuilder, queryBuilder)
-            IUserClient::class.java -> UserClient(client, requestBuilder)
-            IImmunizationDeciderClient::class.java -> ImmunizationDeciderClient(client, requestBuilder, queryBuilder)
-            IImmunizationHistoryClient::class.java -> ImmunizationHistoryClient(client, requestBuilder, queryBuilder)
-            IPharmacyClient::class.java -> PharmacyClient(client, requestBuilder)
+            IMockPharmacyClient::class.java -> MockPharmacyClient(client, queryBuilder)
+            IUserClient::class.java -> UserClient(client)
+            IImmunizationDeciderClient::class.java -> ImmunizationDeciderClient(client, queryBuilder)
+            IImmunizationHistoryClient::class.java -> ImmunizationHistoryClient(client, queryBuilder)
+            IPharmacyClient::class.java -> PharmacyClient(client)
             else -> throw Exception("class '${clazz}' is not a valid client!")
         } as T
     }

--- a/example-service-under-test/src/main/kotlin/co/tala/example/http/client/lib/mock/MockImmunizationHistoryClient.kt
+++ b/example-service-under-test/src/main/kotlin/co/tala/example/http/client/lib/mock/MockImmunizationHistoryClient.kt
@@ -19,7 +19,6 @@ interface IMockImmunizationHistoryClient {
 
 class MockImmunizationHistoryClient(
     private val client: IExampleHttpClient,
-    private val requestHeaderBuilder: IRequestHeaderBuilder,
     private val queryParamBuilder: IQueryParamBuilder
 ) : IMockImmunizationHistoryClient {
     override fun setUpGetHistory(
@@ -27,12 +26,10 @@ class MockImmunizationHistoryClient(
         request: MockData<ImmunizationHistoryResponse>
     ): ApiResponse<MockData<ImmunizationHistoryResponse>> = client.post(
         uri = "/immunizations${queryParamBuilder.clear().addParam("userId", userId).build()}",
-        headers = requestHeaderBuilder.clear().build(),
         content = request
     ).apiResponse()
 
     override fun verifyGetHistory(userId: String): ApiResponse<List<Any>> = client.get(
-        uri = "/immunizations${queryParamBuilder.clear().addParam("userId", userId).build()}",
-        headers = requestHeaderBuilder.clear().build()
+        uri = "/immunizations${queryParamBuilder.clear().addParam("userId", userId).build()}"
     ).apiResponse()
 }

--- a/example-service-under-test/src/main/kotlin/co/tala/example/http/client/lib/mock/MockPharmacyClient.kt
+++ b/example-service-under-test/src/main/kotlin/co/tala/example/http/client/lib/mock/MockPharmacyClient.kt
@@ -15,20 +15,17 @@ interface IMockPharmacyClient {
 
 class MockPharmacyClient(
     private val client: IExampleHttpClient,
-    private val requestHeaderBuilder: IRequestHeaderBuilder,
     private val queryParamBuilder: IQueryParamBuilder
 ) : IMockPharmacyClient {
     override fun setUpPostImmunizationDecision(sourceRefId: String, request: MockData<Unit>): ApiResponse<Unit> =
         client.post(
             uri = "/immunizations/decisions${sourceRefIdQuery(sourceRefId)}",
-            headers = requestHeaderBuilder.clear().build(),
             content = request
         ).apiResponse()
 
     override fun verifyPostImmunizationDecision(sourceRefId: String): ApiResponse<List<ImmunizationDecisionStatusResponse>> =
         client.get(
-            uri = "/immunizations/decisions${sourceRefIdQuery(sourceRefId)}",
-            headers = requestHeaderBuilder.clear().build(),
+            uri = "/immunizations/decisions${sourceRefIdQuery(sourceRefId)}"
         ).apiResponse()
 
     private fun sourceRefIdQuery(sourceRefId: String) =

--- a/example-service-under-test/src/main/kotlin/co/tala/example/http/client/lib/mock/MockUserClient.kt
+++ b/example-service-under-test/src/main/kotlin/co/tala/example/http/client/lib/mock/MockUserClient.kt
@@ -13,18 +13,15 @@ interface IMockUserClient {
 }
 
 class MockUserClient(
-    private val client: IExampleHttpClient,
-    private val requestHeaderBuilder: IRequestHeaderBuilder
+    private val client: IExampleHttpClient
 ) : IMockUserClient {
     override fun setUpGetUser(userId: String, request: MockData<UserResponse>): ApiResponse<MockData<UserResponse>> =
         client.post(
             uri = "/users/$userId",
-            headers = requestHeaderBuilder.clear().build(),
             content = request
         ).apiResponse()
 
     override fun verifyGetUser(userId: String): ApiResponse<List<Any>> = client.get(
-        uri = "/users/$userId",
-        headers = requestHeaderBuilder.clear().build(),
+        uri = "/users/$userId"
     ).apiResponse()
 }

--- a/example-service-under-test/src/main/kotlin/co/tala/example/http/client/lib/service/immunization_decider/ImmunizationDeciderClient.kt
+++ b/example-service-under-test/src/main/kotlin/co/tala/example/http/client/lib/service/immunization_decider/ImmunizationDeciderClient.kt
@@ -15,17 +15,14 @@ interface IImmunizationDeciderClient {
 
 class ImmunizationDeciderClient(
     private val client: IExampleHttpClient,
-    private val requestHeaderBuilder: IRequestHeaderBuilder,
     private val queryParamBuilder: IQueryParamBuilder
 ) : IImmunizationDeciderClient {
     override fun initiateDecision(request: InitiateImmunizationDecisionRequest): ApiResponse<Unit> = client.post(
         uri = "/decisions",
-        headers = requestHeaderBuilder.clear().build(),
         content = request
     ).apiResponse()
 
     override fun getStatus(sourceRefId: String): ApiResponse<ImmunizationDecisionStatusResponse> = client.get(
-        uri = "/decisions${queryParamBuilder.clear().addParam("sourceRefId", sourceRefId).build()}",
-        headers = requestHeaderBuilder.clear().build()
+        uri = "/decisions${queryParamBuilder.clear().addParam("sourceRefId", sourceRefId).build()}"
     ).apiResponse()
 }

--- a/example-service-under-test/src/main/kotlin/co/tala/example/http/client/lib/service/immunization_history/ImmunizationHistoryClient.kt
+++ b/example-service-under-test/src/main/kotlin/co/tala/example/http/client/lib/service/immunization_history/ImmunizationHistoryClient.kt
@@ -13,12 +13,10 @@ interface IImmunizationHistoryClient {
 
 class ImmunizationHistoryClient(
     private val client: IExampleHttpClient,
-    private val requestHeaderBuilder: IRequestHeaderBuilder,
     private val queryParamBuilder: IQueryParamBuilder
 ) : IImmunizationHistoryClient {
     override fun getHistory(userId: String): ApiResponse<ImmunizationHistoryResponse> = client.get(
-        uri = "/immunizations${queryParamBuilder.clear().addParam("userId", userId).build()}",
-        headers = requestHeaderBuilder.clear().build()
+        uri = "/immunizations${queryParamBuilder.clear().addParam("userId", userId).build()}"
     ).apiResponse()
 
 }

--- a/example-service-under-test/src/main/kotlin/co/tala/example/http/client/lib/service/pharmacy/PharmacyClient.kt
+++ b/example-service-under-test/src/main/kotlin/co/tala/example/http/client/lib/service/pharmacy/PharmacyClient.kt
@@ -11,12 +11,10 @@ interface IPharmacyClient {
 }
 
 class PharmacyClient(
-    private val client: IExampleHttpClient,
-    private val requestHeaderBuilder: IRequestHeaderBuilder
+    private val client: IExampleHttpClient
 ) : IPharmacyClient {
     override fun postImmunizationDecision(request: ImmunizationDecisionStatusResponse): ApiResponse<Unit> = client.post(
         uri = "/immunizations/decisions",
-        headers = requestHeaderBuilder.clear().build(),
         content = request
     ).apiResponse()
 }

--- a/example-service-under-test/src/main/kotlin/co/tala/example/http/client/lib/service/user/UserClient.kt
+++ b/example-service-under-test/src/main/kotlin/co/tala/example/http/client/lib/service/user/UserClient.kt
@@ -11,11 +11,7 @@ interface IUserClient {
 }
 
 class UserClient(
-    private val client: IExampleHttpClient,
-    private val requestHeaderBuilder: IRequestHeaderBuilder
+    private val client: IExampleHttpClient
 ) : IUserClient {
-    override fun getUser(userId: String): ApiResponse<UserResponse> = client.get(
-        uri = "/users/$userId",
-        headers = requestHeaderBuilder.clear().build()
-    ).apiResponse()
+    override fun getUser(userId: String): ApiResponse<UserResponse> = client.get(uri = "/users/$userId").apiResponse()
 }

--- a/example-service-under-test/src/test/kotlin/co/tala/example/http/client/core/ExampleHttpClientSpec.kt
+++ b/example-service-under-test/src/test/kotlin/co/tala/example/http/client/core/ExampleHttpClientSpec.kt
@@ -1,13 +1,19 @@
 package co.tala.example.http.client.core
 
 
+import co.tala.example.http.client.core.ExampleHttpMethod.*
+import co.tala.example.http.client.core.request.*
+import co.tala.example.http.client.lib.builder.IRequestHeaderBuilder
 import com.google.gson.Gson
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.mockk.every
-import io.mockk.mockk
+import io.kotest.matchers.string.shouldMatch
+import io.mockk.*
 import okhttp3.*
+import okhttp3.Call
+import okhttp3.RequestBody.Companion.toRequestBody
+import okio.Buffer
 import java.io.InputStream
 import java.net.URL
 import java.time.Instant
@@ -24,6 +30,34 @@ class ExampleHttpClientSpec : WordSpec({
         val list: List<String>
     )
 
+    data class SomeMultipartFormDataBodyRequest(
+        val foo: String,
+        val bar: String,
+        val file: String
+    ) : MultipartFormDataBodyRequest {
+        override fun toRequestBody(): MultipartBody = build {
+            tryAddFormData("foo", foo)
+            tryAddFormData("bar", bar)
+            tryAddFormData("file", "/someFile", file.toRequestBody())
+        }
+    }
+
+    data class SomeFormBodyRequest(
+        val foo: String,
+        val bar: String
+    ) : FormBodyRequest {
+        override fun toRequestBody(): FormBody = build {
+            tryAddFormData("foo", foo)
+            tryAddFormData("bar", bar)
+        }
+    }
+
+    data class RequestCapture(
+        val contentType: String?,
+        val method: String,
+        val bodyUtf8: String?
+    )
+
     fun testModel(): TestModel = TestModel(
         integer = Random.nextInt(),
         long = Random.nextLong(),
@@ -34,10 +68,24 @@ class ExampleHttpClientSpec : WordSpec({
     val someResponse = testModel()
     val someRequest = testModel()
     val someHeaders = mapOf("foo" to "bar")
+    val someMockedHeaders = mapOf("ice" to "cream")
     val someMultiMap = mapOf("foo1" to listOf("bar1"))
-    val serializedResponse: String = gson.toJson(someResponse)
+    val someMultipartFormDataBodyRequest: MultipartBodyRequest = SomeMultipartFormDataBodyRequest(
+        foo = Random.nextInt().toString(),
+        bar = Random.nextInt().toString(),
+        file = Random.nextInt().toString()
+    )
+    val someFormBodyRequest: FormBodyRequest = SomeFormBodyRequest(
+        foo = Random.nextInt().toString(),
+        bar = Random.nextInt().toString()
+    )
+    val serializedResponse: String = gson.toJson(listOf(someResponse))
 
-    fun rawResponse(method: ExampleHttpMethod): RawResponse {
+    fun createRawResponse(
+        method: ExampleHttpMethod,
+        serializedResponse: String,
+        someMultiMap: Map<String, List<String>>
+    ): RawResponse {
         val okHttpResponseMock: Response = mockk()
         val responseBodyMock: ResponseBody = mockk()
         val streamMock: InputStream = mockk()
@@ -45,7 +93,7 @@ class ExampleHttpClientSpec : WordSpec({
         val requestMock: Request = mockk()
         val headersMock: Headers = mockk()
         val urlMock: HttpUrl = mockk()
-        val fakeUrl: URL = URL("http", "someHost", 1234, "/someResource")
+        val fakeUrl = URL("http", "someHost", 1234, "/someResource")
 
         every { streamMock.readAllBytes() } returns bytes
         every { responseBodyMock.byteStream() } returns streamMock
@@ -59,60 +107,105 @@ class ExampleHttpClientSpec : WordSpec({
         every { okHttpResponseMock.request } returns requestMock
 
         return RawResponse(
-            gson = gson,
+            gson = Gson(),
             okHttpResponse = okHttpResponseMock,
             start = Instant.now(),
             end = Instant.now()
         )
     }
 
-    fun clientMock(method: ExampleHttpMethod): OkHttpClient {
+    fun requestHeaderBuilderMock(returnedHeaders: Map<String, String>): IRequestHeaderBuilder {
+        val builderMock = mockk<IRequestHeaderBuilder>()
+        every {
+            builderMock.addHeader(any(), any())
+        } returns builderMock
+        every {
+            builderMock.clear()
+        } returns builderMock
+        every {
+            builderMock.build()
+        } returns returnedHeaders
+        return builderMock
+    }
+
+    fun clientMock(method: ExampleHttpMethod, assertion: (RequestCapture) -> Unit): OkHttpClient {
+        val slot: CapturingSlot<Request> = slot()
         val clientMock: OkHttpClient = mockk()
-        val rawResponse = rawResponse(method)
+        val rawResponse = createRawResponse(method, serializedResponse, someMultiMap)
         val callMock: Call = mockk()
         every {
             callMock.execute()
         } returns rawResponse.okHttpResponse
 
         every {
-            clientMock.newCall(any())
-        } returns callMock
+            clientMock.newCall(request = capture(slot))
+        } answers {
+            val capture = slot.captured
+            Buffer().use { sink ->
+                capture.body?.writeTo(sink)
+                assertion(
+                    RequestCapture(
+                        contentType = capture.body?.contentType()?.toString(),
+                        method = capture.method,
+                        bodyUtf8 = sink.readUtf8()
+                    )
+                )
+            }
+            callMock
+        }
 
         return clientMock
     }
 
     "send request" should {
-        ExampleHttpMethod.values().forEach { method ->
-            "send a $method request" {
+        values().forEach { method ->
+            val specName = when (method) {
+                POST, PUT, PATCH -> "succeed for a $method with json request body"
+                GET, DELETE -> "succeed for a $method with no request body"
+            }
+            specName {
                 val uri = "/some-uri"
-                val clientMock = clientMock(method)
-                val sut: IExampleHttpClient = ExampleHttpClient(clientMock, baseUrl, gson)
+                val clientMock = clientMock(method) { requestCapture ->
+                    requestCapture.method shouldBe method.name
+                    requestCapture.contentType shouldBe when (method) {
+                        POST, PATCH, PUT -> ContentType.APPLICATION_JSON.value + "; charset=utf-8"
+                        GET, DELETE -> null
+                    }
+                    requestCapture.bodyUtf8 shouldBe when (method) {
+                        POST, PATCH, PUT -> gson.toJson(someRequest)
+                        GET, DELETE -> ""
+                    }
+                }
+                val requestHeaderBuilderMock = requestHeaderBuilderMock(someMockedHeaders)
+                val sut: IExampleHttpClient = ExampleHttpClient(clientMock, requestHeaderBuilderMock, baseUrl, gson)
 
-                val response: ApiResponse<TestModel> = when (method) {
-                    ExampleHttpMethod.POST -> sut.post(
+                val rawResponse: RawResponse = when (method) {
+                    POST -> sut.post(
                         uri = uri,
                         headers = someHeaders,
                         content = someRequest
                     )
-                    ExampleHttpMethod.PUT -> sut.put(
+                    PUT -> sut.put(
                         uri = uri,
                         headers = someHeaders,
                         content = someRequest
                     )
-                    ExampleHttpMethod.PATCH -> sut.patch(
+                    PATCH -> sut.patch(
                         uri = uri,
                         headers = someHeaders,
                         content = someRequest
                     )
-                    ExampleHttpMethod.GET -> sut.get(
+                    GET -> sut.get(
                         uri = uri,
                         headers = someHeaders
                     )
-                    ExampleHttpMethod.DELETE -> sut.delete(
+                    DELETE -> sut.delete(
                         uri = uri,
                         headers = someHeaders
                     )
-                }.apiResponse()
+                }
+                // Verify deserialization to data class
+                val response: ApiResponse<List<TestModel>> = rawResponse.apiResponse()
 
                 response.method shouldBe method
                 response.url shouldBe "http://someHost:1234/someResource"
@@ -121,17 +214,29 @@ class ExampleHttpClientSpec : WordSpec({
                 response.statusCode shouldBe 200
                 response.body shouldNotBe null
                 val actualBody = response.body!!
-                actualBody.integer shouldBe someResponse.integer
-                actualBody.long shouldBe someResponse.long
-                actualBody.string shouldBe someResponse.string
-                actualBody.list shouldBe someResponse.list
+                actualBody.first().integer shouldBe someResponse.integer
+                actualBody.first().long shouldBe someResponse.long
+                actualBody.first().string shouldBe someResponse.string
+                actualBody.first().list shouldBe someResponse.list
+
+                // Verify as ByteArray with no deserialization
+                val responseBytes = rawResponse.apiResponse<ByteArray>()
+                val expectedBytes = serializedResponse.toByteArray()
+                val actualBytes = responseBytes.body!!
+                actualBytes shouldBe expectedBytes
+
+                verifyOrder {
+                    requestHeaderBuilderMock.clear()
+                    requestHeaderBuilderMock.build()
+                }
             }
         }
 
         "return a null response on failed deserialization" {
             val uri = "/some-uri"
-            val clientMock = clientMock(ExampleHttpMethod.POST)
-            val sut: IExampleHttpClient = ExampleHttpClient(clientMock, baseUrl, gson)
+            val clientMock = clientMock(POST) {}
+            val requestHeaderBuilderMock = requestHeaderBuilderMock(someMockedHeaders)
+            val sut: IExampleHttpClient = ExampleHttpClient(clientMock, requestHeaderBuilderMock, baseUrl, gson)
 
             val response = sut.post(
                 uri = uri,
@@ -140,6 +245,96 @@ class ExampleHttpClientSpec : WordSpec({
             ).apiResponse<Long>()
 
             response.body shouldBe null
+        }
+
+        "succeed for a multi part form data request" {
+            val uri = "/some-uri"
+            val clientMock = clientMock(POST) { requestCapture ->
+                requestCapture shouldNotBe null
+                requestCapture.method shouldBe "POST"
+                requestCapture.contentType!! shouldMatch Regex("""${ContentType.MULTIPART_FORM_DATA.value}; (.*)""")
+            }
+            val requestHeaderBuildMock = requestHeaderBuilderMock(mapOf("foo" to "bar"))
+            val sut: IExampleHttpClient = ExampleHttpClient(clientMock, requestHeaderBuildMock, baseUrl, gson)
+
+            sut.post(
+                uri = uri,
+                content = someMultipartFormDataBodyRequest
+            )
+        }
+
+        "succeed for a form request" {
+            val uri = "/some-uri"
+            val clientMock = clientMock(POST) { requestCapture ->
+                requestCapture.contentType shouldBe ContentType.APPLICATION_X_WWW_FORM_URLENCODED.value
+            }
+            val requestHeaderBuildMock = requestHeaderBuilderMock(mapOf("foo" to "bar"))
+            val sut: IExampleHttpClient = ExampleHttpClient(clientMock, requestHeaderBuildMock, baseUrl, gson)
+
+            sut.post(
+                uri = uri,
+                content = someFormBodyRequest
+            )
+        }
+
+        "succeed for a byte arrary request" {
+            val uri = "/some-uri"
+            val clientMock = clientMock(POST) { requestCapture ->
+                requestCapture.contentType shouldBe ContentType.APPLICATION_OCTET_STREAM.value
+                requestCapture.bodyUtf8 shouldBe "123"
+            }
+            val requestHeaderBuildMock = requestHeaderBuilderMock(mapOf("foo" to "bar"))
+            val sut: IExampleHttpClient = ExampleHttpClient(clientMock, requestHeaderBuildMock, baseUrl, gson)
+
+            sut.post(
+                uri = uri,
+                content = "123".toByteArray()
+            )
+        }
+
+        "succeed for an octet steam request" {
+            val uri = "/some-uri"
+            val clientMock = clientMock(PATCH) { requestCapture ->
+                requestCapture.contentType shouldBe ContentType.APPLICATION_OCTET_STREAM.value
+                requestCapture.bodyUtf8 shouldBe "123"
+            }
+            val requestHeaderBuildMock = requestHeaderBuilderMock(mapOf("foo" to "bar"))
+            val sut: IExampleHttpClient = ExampleHttpClient(clientMock, requestHeaderBuildMock, baseUrl, gson)
+
+            sut.patch(
+                uri = uri,
+                content = OctetStreamBodyRequest("123".toByteArray())
+            )
+        }
+
+        "succeed for an offset octet steam request" {
+            val uri = "/some-uri"
+            val clientMock = clientMock(PATCH) { requestCapture ->
+                requestCapture.contentType shouldBe ContentType.APPLICATION_OFFSET_OCTET_STREAM.value
+                requestCapture.bodyUtf8 shouldBe "123"
+            }
+            val requestHeaderBuildMock = requestHeaderBuilderMock(mapOf("foo" to "bar"))
+            val sut: IExampleHttpClient = ExampleHttpClient(clientMock, requestHeaderBuildMock, baseUrl, gson)
+
+            sut.patch(
+                uri = uri,
+                content = OffsetOctetStreamBodyRequest("123".toByteArray())
+            )
+        }
+
+        "succeed for a string request body" {
+            val uri = "/some-uri"
+            val clientMock = clientMock(POST) { requestCapture ->
+                requestCapture.contentType shouldBe "${ContentType.TEXT_PLAIN.value}; charset=utf-8"
+                requestCapture.bodyUtf8 shouldBe "123"
+            }
+            val requestHeaderBuildMock = requestHeaderBuilderMock(mapOf("foo" to "bar"))
+            val sut: IExampleHttpClient = ExampleHttpClient(clientMock, requestHeaderBuildMock, baseUrl, gson)
+
+            sut.post(
+                uri = uri,
+                content = "123"
+            )
         }
     }
 


### PR DESCRIPTION
update example client library with latest features:

- Add support for various request content types: form data, multi part form data, binary, and string.
- Move `IRequestHeaderBuilder` reference to `ExampleHttpClient` layer for simpler business layer.