### PR TITLE
Sync with internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Immunization Decider Service) with example integration specs utilizing Fake Depe
 * [Examples of Using Fake Dependency Service](#examples-of-using-fake-dependency-service)
 * [Http Client Library](#http-client-library)
 * [Example Integration Specs](#example-integration-specs)
+* [Debugging Service Under Test](#debugging-service-under-test)
 
 ## How to Start All Services in Docker and Run Tests
 
@@ -720,3 +721,33 @@ Assertion Failure 2
 Assertion failed! Hint: 'string'
 expected:<"bar"> but was:<"foo">
 ```
+
+## Debugging Service Under Test
+
+To see incoming requests from the service under test, you can enable the logging by setting `LOG_REQUESTS_LEVEL` to `DEBUG` in your environment.
+
+In your `docker-compose.yaml` file:
+```
+  fake-dependency-service:
+    container_name: fake-dependency
+    hostname: fake-dependency
+    ...
+    environment:
+      LOG_REQUESTS_LEVEL: DEBUG
+      ...
+```
+In the `Fake Dependency` logs, you will see entries like this:
+
+```
+09-06-2022 00:03:06.860 [http-nio-8099-exec-1] DEBUG o.s.w.f.CommonsRequestLoggingFilter.afterRequest - Incoming Request:
+POST /mock-service/some-auth-service/mock-resources, headers=[x-request-id:"11111111-1111-1111-1111-8c25c9876209",
+user-agent:"PostmanRuntime/7.29.0", accept:"*/*", cache-control:"no-cache", postman-token:"ce867add-e59c-4c94-b92f-57f2a8b2d77e",
+host:"localhost.proxyman.io:8099", accept-encoding:"gzip, deflate, br", connection:"keep-alive", content-length:"860",
+Content-Type:"application/json;charset=UTF-8"], payload={
+    "responseBody": {
+        "Token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.
+    ...
+```
+
+This way, if you get an error message, `Mock not setup!`, then you can determine what the service under test
+is sending the `Fake Dependency` service.

--- a/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/business/parser/IPayloadParser.kt
+++ b/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/business/parser/IPayloadParser.kt
@@ -9,5 +9,5 @@ interface IPayloadParser {
      * and not the payload because parsing a payload is expensive, which impacts on performance.
      * Parsing the payload should be used as a last resort for mock id uniqueness.
      */
-    fun parse(payload: Any, key: String): String
+    fun parse(payload: Any, key: String): String?
 }

--- a/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/business/parser/PayloadParser.kt
+++ b/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/business/parser/PayloadParser.kt
@@ -12,25 +12,25 @@ class PayloadParser(
     private val xmlMapper: XmlMapper
 ) : IPayloadParser {
 
-    override fun parse(payload: Any, key: String): String = findValue(payload, key.split('.'), 0)
+    override fun parse(payload: Any, key: String): String? = findValue(payload, key.split('.'), 0)
 
     @Suppress("UNCHECKED_CAST")
-    private fun findValue(any: Any, keys: List<String>, depth: Int): String = when {
+    private fun findValue(any: Any, keys: List<String>, depth: Int): String? = when {
         keys.size == depth -> any.toString()
         any is Map<*, *> -> findValueInMap(any as Map<String, Any>, keys, depth)
         any is String -> findValueInXmlString(any.toString(), keys, depth)
         else -> throw PayloadTypeNotSupportedException(any)
     }
 
-    private fun findValueInXmlString(xml: String, keys: List<String>, depth: Int): String {
+    private fun findValueInXmlString(xml: String, keys: List<String>, depth: Int): String? {
         val any = xmlMapper.readValue(xml, Any::class.java)
         val map = mapper.convertValue(any, object : TypeReference<Map<String, Any>>() {})
         return findValueInMap(map, keys, depth)
     }
 
-    private fun findValueInMap(map: Map<String, Any>, keys: List<String>, depth: Int): String {
+    private fun findValueInMap(map: Map<String, Any>, keys: List<String>, depth: Int): String? {
         val key = keys[depth]
-        val child = map.getOrElse(key) { throw NoSuchElementException("Key $key does not exist in map $map") }
+        val child = map.getOrElse(key) { return null }
         return findValue(child, keys, depth + 1)
     }
 

--- a/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/business/parser/QueryParser.kt
+++ b/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/business/parser/QueryParser.kt
@@ -15,5 +15,8 @@ class QueryParser : IQueryParser {
             it.key == VerifyMockContent.QUERY_PARAM_KEY
         }?.map { entry ->
             entry.key to entry.value.map { value -> value.split('=').last() }
+        }?.sortedBy {
+            // sort keys so that query param order does not matter
+            it.first
         }?.toMap() ?: emptyMap()
 }

--- a/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/business/provider/FakeDependencyProvider.kt
+++ b/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/business/provider/FakeDependencyProvider.kt
@@ -39,10 +39,12 @@ internal class FakeDependencyProvider(
             request = request,
             includeWithoutRequestId = false
         ).forEach { redisKey ->
+            val keys = query.keys
+            val values = query.values
             if (query.isNotEmpty()) {
-                redisSvc.pushSetValue(RedisKeyPrefix.QUERY, redisKey, query)
+                redisSvc.pushSetValues(RedisKeyPrefix.QUERY, redisKey, *keys.toTypedArray())
             }
-            val redisKeyWithQuery = keyHelper.concatenateKeys(redisKey, *query.keys.plus(query.values).toTypedArray())
+            val redisKeyWithQuery = keyHelper.concatenateKeys(redisKey, *keys.plus(values).toTypedArray())
             redisSvc.pushListValue(RedisKeyPrefix.EXECUTE, redisKeyWithQuery, mockData)
         }
         return ResponseEntity.ok(mockData)

--- a/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/configuration/helper/RequestLoggingFilterConfig.kt
+++ b/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/configuration/helper/RequestLoggingFilterConfig.kt
@@ -1,0 +1,27 @@
+package co.tala.api.fakedependency.configuration.helper
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.filter.CommonsRequestLoggingFilter
+
+
+@Configuration
+class RequestLoggingFilterConfig {
+
+    /**
+     * For local testing. Logs incoming requests to this service,
+     * which can help identify mocks that were not set up.
+     *
+     * @see: https://www.baeldung.com/spring-http-logging
+     */
+    @Bean
+    fun logFilter(): CommonsRequestLoggingFilter =
+        CommonsRequestLoggingFilter().also { filter ->
+            filter.setIncludeQueryString(true)
+            filter.setIncludePayload(true)
+            filter.setMaxPayloadLength(10000)
+            filter.setIncludeHeaders(true)
+            filter.setAfterMessagePrefix("Incoming Request: ")
+        }
+
+}

--- a/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/model/MockData.kt
+++ b/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/model/MockData.kt
@@ -1,6 +1,6 @@
 package co.tala.api.fakedependency.model
 
-import org.springframework.http.HttpStatus
+import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 import org.springframework.util.CollectionUtils
 import javax.validation.constraints.NotNull
@@ -13,9 +13,10 @@ class MockData(
     @field: NotNull
     val responseHeaders: Map<String, List<String>> = emptyMap()
 ) {
-    fun toResponseEntity(): ResponseEntity<Any> = ResponseEntity(
-        responseBody,
-        CollectionUtils.toMultiValueMap(responseHeaders),
-        HttpStatus.valueOf(responseSetUpMetadata.httpStatus)
-    )
+    fun toResponseEntity(): ResponseEntity<Any> {
+        return ResponseEntity
+            .status(responseSetUpMetadata.httpStatus)
+            .headers(HttpHeaders(CollectionUtils.toMultiValueMap(responseHeaders)))
+            .body(responseBody)
+    }
 }

--- a/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/redis/IRedisService.kt
+++ b/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/redis/IRedisService.kt
@@ -8,6 +8,7 @@ interface IRedisService {
     fun <T : Any> pushListValue(keyPrefix: String, key: String, value: T?)
     fun <T : Any> popListValue(keyPrefix: String, key: String, type: TypeReference<T>): T?
     fun <T : Any> getListValues(keyPrefix: String, key: String, type: TypeReference<List<T>>): List<T>
-    fun <T : Any> pushSetValue(keyPrefix: String, key: String, value: T)
+    fun <T : Any> pushSetValues(keyPrefix: String, key: String, vararg values: T)
     fun <T : Any> getSetValues(keyPrefix: String, key: String, type: TypeReference<Set<T>>): Set<T>
+    fun hasKey(keyPrefix: String, opsType: RedisOpsType, key: String): Boolean
 }

--- a/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/redis/RedisOpsType.kt
+++ b/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/redis/RedisOpsType.kt
@@ -1,0 +1,5 @@
+package co.tala.api.fakedependency.redis
+
+enum class RedisOpsType {
+    LIST, SET, VALUE
+}

--- a/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/redis/RedisService.kt
+++ b/fake-dependency-service/src/main/kotlin/co/tala/api/fakedependency/redis/RedisService.kt
@@ -18,20 +18,20 @@ class RedisService(
     private val ttl = redisConfig.ttl
 
     override fun <T : Any> setValue(keyPrefix: String, key: String, value: T?) {
-        val valueKey = "$keyPrefix-value-$key"
+        val valueKey = makeKey(keyPrefix, RedisOpsType.VALUE, key)
         val any = mapper.convertValue(value, object : TypeReference<Any>() {})
         redisOperations.opsForValue().set(valueKey, any)
         redisOperations.expire(valueKey, ttl, TimeUnit.SECONDS)
     }
 
     override fun <T : Any> getValue(keyPrefix: String, key: String, type: TypeReference<T>): T? {
-        val valueKey = "$keyPrefix-value-$key"
+        val valueKey = makeKey(keyPrefix, RedisOpsType.VALUE, key)
         val any: Any? = redisOperations.opsForValue().get(valueKey)
         return if (any != null) mapper.convertValue(any, type) else null
     }
 
     override fun <T : Any> pushListValue(keyPrefix: String, key: String, value: T?) {
-        val listKey = "$keyPrefix-list-$key"
+        val listKey = makeKey(keyPrefix, RedisOpsType.LIST, key)
         val any = mapper.convertValue(value, object : TypeReference<Any>() {})
         val opsForList: ListOperations<Any, Any> = redisOperations.opsForList()
         opsForList.rightPush(listKey, any)
@@ -41,7 +41,7 @@ class RedisService(
     }
 
     override fun <T : Any> popListValue(keyPrefix: String, key: String, type: TypeReference<T>): T? {
-        val listKey = "$keyPrefix-list-$key"
+        val listKey = makeKey(keyPrefix, RedisOpsType.LIST, key)
         val opsForList: ListOperations<Any, Any> = redisOperations.opsForList()
         val any: Any? = opsForList.leftPop(listKey)
         // If list is empty or not found, then try from getValue, which stores the last mocked response
@@ -49,7 +49,7 @@ class RedisService(
     }
 
     override fun <T : Any> getListValues(keyPrefix: String, key: String, type: TypeReference<List<T>>): List<T> {
-        val listKey = "$keyPrefix-list-$key"
+        val listKey = makeKey(keyPrefix, RedisOpsType.LIST, key)
         val opsForList: ListOperations<Any, Any> = redisOperations.opsForList()
         return mapper.convertValue(
             opsForList.range(listKey, 0, opsForList.size(listKey) ?: 0),
@@ -57,17 +57,25 @@ class RedisService(
         )
     }
 
-    override fun <T : Any> pushSetValue(keyPrefix: String, key: String, value: T) {
-        val setKey = "$keyPrefix-set-$key"
+    override fun <T : Any> pushSetValues(keyPrefix: String, key: String, vararg values: T) {
+        val setKey = makeKey(keyPrefix, RedisOpsType.SET, key)
         val opsForSet: SetOperations<Any, Any> = redisOperations.opsForSet()
-        opsForSet.add(setKey, value)
+        opsForSet.add(setKey, *values)
         redisOperations.expire(setKey, ttl, TimeUnit.SECONDS)
     }
 
     override fun <T : Any> getSetValues(keyPrefix: String, key: String, type: TypeReference<Set<T>>): Set<T> {
-        val setKey = "$keyPrefix-set-$key"
+        val setKey = makeKey(keyPrefix, RedisOpsType.SET, key)
         val opsForSet: SetOperations<Any, Any> = redisOperations.opsForSet()
         val members: Set<Any>? = opsForSet.members(setKey)
         return if (members != null) mapper.convertValue(members, type) else emptySet()
     }
+
+    override fun hasKey(keyPrefix: String, opsType: RedisOpsType, key: String): Boolean {
+        val redisKey = makeKey(keyPrefix, opsType, key)
+        return redisOperations.hasKey(redisKey) ?: false
+    }
+
+    private fun makeKey(keyPrefix: String, opsType: RedisOpsType, key: String): String =
+        "$keyPrefix-${opsType.toString().lowercase()}-$key"
 }

--- a/fake-dependency-service/src/main/resources/application.properties
+++ b/fake-dependency-service/src/main/resources/application.properties
@@ -10,3 +10,5 @@ config.default.callbacks.maximumDelay=3000
 config.default.callbacks.enabled=true
 # Request ID: Define request headers to used for mock ids, delimited by ','. X-Request-ID,X-Header-A,X-Header-B are for samples
 config.request.id.headers=X-Request-ID,X-Header-A,X-Header-B
+# Log incoming requests, requires DEBUG level to see anything
+logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=${LOG_REQUESTS_LEVEL:WARN}

--- a/fake-dependency-service/src/test/groovy/co/tala/api/fakedependency/business/composer/RedisKeyWithQueryComposerSpec.groovy
+++ b/fake-dependency-service/src/test/groovy/co/tala/api/fakedependency/business/composer/RedisKeyWithQueryComposerSpec.groovy
@@ -5,6 +5,7 @@ import co.tala.api.fakedependency.business.parser.IPayloadParser
 import co.tala.api.fakedependency.business.parser.IQueryParser
 import co.tala.api.fakedependency.redis.IRedisService
 import co.tala.api.fakedependency.redis.RedisKeyPrefix
+import co.tala.api.fakedependency.redis.RedisOpsType
 import com.fasterxml.jackson.core.type.TypeReference
 import spock.lang.Specification
 
@@ -12,9 +13,10 @@ import javax.servlet.http.HttpServletRequest
 
 class RedisKeyWithQueryComposerSpec extends Specification {
     private static final KEYS = ["key1", "key2"]
-    private static final Map<String, List<String>> QUERY_2_MAP = ["num": ["5"], "animal": ["dog", "cat"]]
-    private static final Set<Map<String, List<String>>> QUERY_2_SET_MAP = [["num": ["5"], "animal": ["dog", "cat"]]]
+    private static final Map<String, List<String>> QUERY_MAP = ["num": ["5"], "animal": ["dog", "cat"]]
+    private static final Set<String> QUERY_KEY_SET = ["num", "animal"]
     private static final Map<String, List<String>> QUERY_EMPTY_MAP = [:]
+    private static final List<String> RESULTS = ["result0", "result1"]
 
     private HttpServletRequest requestMock
     private String requestId
@@ -40,27 +42,30 @@ class RedisKeyWithQueryComposerSpec extends Specification {
         given: "the same map of 2 entries exists in Redis and the request query"
             def payload = "some payload"
             1 * redisKeyComposerMock.getKeys(requestId, requestMock, true) >> KEYS
-            2 * queryParserMock.getQuery(requestMock) >> QUERY_2_MAP
-            2 * redisSvcMock.getSetValues(RedisKeyPrefix.QUERY, _, _ as TypeReference) >> { arg ->
+            2 * queryParserMock.getQuery(requestMock) >> QUERY_MAP
+            0 * redisSvcMock.getSetValues(RedisKeyPrefix.QUERY, _, _ as TypeReference) >> { arg ->
                 def params = arg as List
                 assert params[0].toString() == RedisKeyPrefix.QUERY
                 assert params[1].toString() == KEYS[0]
-                QUERY_2_SET_MAP
+                QUERY_KEY_SET
             } >> { arg ->
                 def params = arg as List
                 assert params[0].toString() == RedisKeyPrefix.QUERY
                 assert params[1].toString() == KEYS[1]
-                QUERY_2_SET_MAP
+                QUERY_KEY_SET
             }
 
             2 * keyHelperMock.concatenateKeys(*_) >> { arg ->
                 def params = arg[0] as List<String>
                 assert params == [KEYS[0], "num", "animal", ["5"], ["dog", "cat"]]
-                "result0"
+                RESULTS[0]
             } >> { arg ->
                 def params = arg[0] as List<String>
                 assert params == [KEYS[1], "num", "animal", ["5"], ["dog", "cat"]]
                 "result1"
+            }
+            RESULTS.each {
+                1 * redisSvcMock.hasKey(RedisKeyPrefix.EXECUTE, RedisOpsType.VALUE, it) >> true
             }
             0 * payloadParserMock.parse(payload, _)
 
@@ -68,33 +73,35 @@ class RedisKeyWithQueryComposerSpec extends Specification {
             def result = sut.getKeys(requestId, requestMock, payload)
 
         then:
-            result == ["result0", "result1"]
+            result == [RESULTS[0], RESULTS[1]]
     }
 
     def "query values should come from the payload if the uri has no query params"() {
         given: "Redis has a map of 2 query entries, but the uri has none"
             def payload = "some payload"
+            String invalidKey = "invalidKey"
             1 * redisKeyComposerMock.getKeys(requestId, requestMock, true) >> KEYS
             2 * queryParserMock.getQuery(requestMock) >> QUERY_EMPTY_MAP
             2 * redisSvcMock.getSetValues(RedisKeyPrefix.QUERY, _, _ as TypeReference) >> { arg ->
                 def params = arg as List
                 assert params[0].toString() == RedisKeyPrefix.QUERY
                 assert params[1].toString() == KEYS[0]
-                QUERY_2_SET_MAP
+                QUERY_KEY_SET
             } >> { arg ->
                 def params = arg as List
                 assert params[0].toString() == RedisKeyPrefix.QUERY
                 assert params[1].toString() == KEYS[1]
-                QUERY_2_SET_MAP
+                QUERY_KEY_SET
             }
-            2 * keyHelperMock.concatenateKeys(*_) >> { arg ->
+            2 * redisSvcMock.hasKey(RedisKeyPrefix.EXECUTE, RedisOpsType.VALUE, invalidKey) >> false
+            4 * keyHelperMock.concatenateKeys(*_) >> invalidKey >> { arg ->
                 def params = arg[0] as List<String>
                 assert params == [KEYS[0], "num", "animal", ["5"], ["dog"]]
-                "result0"
-            } >> { arg ->
+                RESULTS[0]
+            } >> invalidKey >> { arg ->
                 def params = arg[0] as List<String>
                 assert params == [KEYS[1], "num", "animal", ["5"], ["dog"]]
-                "result1"
+                RESULTS[1]
             }
             4 * payloadParserMock.parse(payload, _) >> { arg ->
                 def params = arg as List
@@ -118,7 +125,7 @@ class RedisKeyWithQueryComposerSpec extends Specification {
             def result = sut.getKeys(requestId, requestMock, payload)
 
         then: "there are 2 results"
-            result == ["result0", "result1"]
+            result == [RESULTS[0], RESULTS[1]]
 
     }
 
@@ -127,15 +134,18 @@ class RedisKeyWithQueryComposerSpec extends Specification {
             def payload = null
             1 * redisKeyComposerMock.getKeys(requestId, requestMock, true) >> KEYS
             2 * queryParserMock.getQuery(requestMock) >> QUERY_EMPTY_MAP
-            2 * redisSvcMock.getSetValues(RedisKeyPrefix.QUERY, _, _ as TypeReference) >> QUERY_2_SET_MAP
-            2 * keyHelperMock.concatenateKeys(*_) >>> ["result0", "result1"]
+            0 * redisSvcMock.getSetValues(RedisKeyPrefix.QUERY, _, _ as TypeReference) >> QUERY_KEY_SET
+            RESULTS.each {
+                1 * redisSvcMock.hasKey(RedisKeyPrefix.EXECUTE, RedisOpsType.VALUE, it) >> true
+            }
+            2 * keyHelperMock.concatenateKeys(*_) >>> [RESULTS[0], RESULTS[1]]
             0 * payloadParserMock.parse(payload, _)
 
         when:
             def result = sut.getKeys(requestId, requestMock, payload)
 
         then:
-            result == ["result0", "result1"]
+            result == [RESULTS[0], RESULTS[1]]
     }
 
 }

--- a/fake-dependency-service/src/test/groovy/co/tala/api/fakedependency/business/parser/PayloadParserSpec.groovy
+++ b/fake-dependency-service/src/test/groovy/co/tala/api/fakedependency/business/parser/PayloadParserSpec.groovy
@@ -46,6 +46,7 @@ class PayloadParserSpec extends Specification {
             "root.childWithChildren.animal" | "dog"
             "root.childWithChildren.number" | "10"
             "leaf"                          | "100"
+            "no.such.leaf"                   | null
     }
 
     def "parse should throw exception if the type passed is not an XML String nor Map"() {
@@ -57,14 +58,6 @@ class PayloadParserSpec extends Specification {
 
         where:
             payload << [5, 0.4, 10L, 0.9f, new InvalidModel()]
-    }
-
-    def "parse should throw exception if the key is not found"() {
-        when: "the key passed does not exist"
-            sut.parse(NESTED_XML, "does.not.exist")
-
-        then: "a NoSuchElementException should be thrown"
-            thrown NoSuchElementException
     }
 
 }

--- a/fake-dependency-service/src/test/groovy/co/tala/api/fakedependency/business/provider/FakeDependencyProviderSpec.groovy
+++ b/fake-dependency-service/src/test/groovy/co/tala/api/fakedependency/business/provider/FakeDependencyProviderSpec.groovy
@@ -9,7 +9,6 @@ import co.tala.api.fakedependency.business.mockdata.MockDataRetrieval
 import co.tala.api.fakedependency.business.parser.IQueryParser
 import co.tala.api.fakedependency.model.DetailedRequestPayloads
 import co.tala.api.fakedependency.model.MockData
-import co.tala.api.fakedependency.model.ResponseSetUpMetadata
 import co.tala.api.fakedependency.redis.IRedisService
 import co.tala.api.fakedependency.redis.RedisKeyPrefix
 import co.tala.api.fakedependency.testutil.MockDataFactory
@@ -90,7 +89,7 @@ class FakeDependencyProviderSpec extends Specification {
             def result = sut.setup(mockData, requestMock)
 
         then: "redisSvc.setValue should not be invoked for the QUERY_KEY"
-            0 * redisSvcMock.pushSetValue(RedisKeyPrefix.QUERY, _, _)
+            0 * redisSvcMock.pushSetValues(RedisKeyPrefix.QUERY, _, _)
         and: "the mock data should be returned"
             result.body == mockData
     }
@@ -102,7 +101,7 @@ class FakeDependencyProviderSpec extends Specification {
             1 * redisKeyComposerMock.getKeys(requestId, requestMock, false) >> REDIS_KEYS
             1 * queryParserMock.getQuery(requestMock) >> QUERY_MAP
             REDIS_KEYS.eachWithIndex { String redisKey, int i ->
-                1 * redisSvcMock.pushSetValue(RedisKeyPrefix.QUERY, redisKey, QUERY_MAP)
+                1 * redisSvcMock.pushSetValues(RedisKeyPrefix.QUERY, redisKey, QUERY_MAP.keySet().toArray())
                 def redisKeyWithQuery = REDIS_KEYS_WITH_QUERY[i]
                 1 * keyHelperMock.concatenateKeys(redisKey, *_) >> { args ->
                     def params = args[0] as List<String>
@@ -146,7 +145,7 @@ class FakeDependencyProviderSpec extends Specification {
             def result = sut.setup(mockData, requestMock)
 
         then: "redisSvc.setValue should not be invoked for the QUERY_KEY"
-            0 * redisSvcMock.pushSetValue(RedisKeyPrefix.QUERY, _, _)
+            0 * redisSvcMock.pushSetValues(RedisKeyPrefix.QUERY, _, _)
         and: "the mock data should be returned"
             result.body == mockData
     }

--- a/fake-dependency-service/src/test/groovy/co/tala/api/fakedependency/testutil/MockDataFactory.groovy
+++ b/fake-dependency-service/src/test/groovy/co/tala/api/fakedependency/testutil/MockDataFactory.groovy
@@ -9,8 +9,7 @@ class MockDataFactory {
         buildCustomMockData([name: 'Elliot Masor', id: 123.4])
     }
 
-    static MockData buildCustomMockData(Object data) {
-        int httpStatus = 200
+    static MockData buildCustomMockData(Object data, int httpStatus = 200) {
         long delayMs = 1
         ResponseSetUpMetadata responseSetUpMetadata = new ResponseSetUpMetadata(httpStatus, delayMs)
         def responseHeaders = ["X-Some-Header": ["some value"]]


### PR DESCRIPTION
Synchronize public repo with latest bug fixes and improvements

[remove NoSuchElementException thrown in PayloadParser](https://github.com/inventure/Fake_Dependency_Service/pull/9/commits/7ea884851738d7aed0b36ca199f01d1e7fab82e0) 
 
[add flag to enable logging of incoming requests](https://github.com/inventure/Fake_Dependency_Service/pull/9/commits/68ea4c2f61b1c04c8df7ee698647c3cc61f106f4) 
 
[enable mocking non standard http response status codes](https://github.com/inventure/Fake_Dependency_Service/pull/9/commits/c4b252ba882f968b247169bf600b69b4a966e665) 
 
[fix perf issue for non unique uris](https://github.com/inventure/Fake_Dependency_Service/pull/9/commits/6ad371609bfebe453fcb520585cfcd5bae29ed88) 

- URI uniqueness is now defined with query params
- Store set of query keys instead of all key value pairs
- Check if key exists in Redis instead of trying to match all query maps from set
- Sort query keys so that order does not matter
- Query key set is only used for parsing payloads

### ALL Tests Pass
![image](https://user-images.githubusercontent.com/44781950/178362410-254ea6e5-0f96-4814-8855-e949c18fc8b5.png)
